### PR TITLE
metadata into setup.cfg, logger problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ FLAKE8_CMD = $(BIN_DIR)/flake8
 FLAKE8_ARGS =
 # This sucks...
 # Shouldn't need a hard-coded path, but my path is messed up.
-SYS_PYTHON_CMD = /usr/bin/python3
+SYS_PYTHON_CMD = $(shell which python3)
+
 #ifeq ($(TRAVIS), 'true')
 ifdef TRAVIS
 	SYS_PYTHON_CMD = python3
@@ -34,7 +35,7 @@ develop: _local_virtualenv pip_reqs setup_develop
 #	sudo apt-get install python3-venv
 _local_virtualenv:
 	$(SYS_PYTHON_CMD) -m venv $(VENV_DIR)
-	$(PIP_CMD) install --upgrade pip
+	$(PIP_CMD) install --upgrade pip setuptools
 
 pip_reqs:
 	$(PIP_CMD) install -r tests/requirements.txt
@@ -63,7 +64,7 @@ clean:
 	rm -rf dist
 	rm -rf $(TESTS_DIR)/.lib
 	# python $(SETUP_PY) clean
-	find lib/work_tools.egg-info -type f -exec rm {} \; || true
+	find .  -name *.egg-info -depth -exec rm -rf {} \; || true
 	find lib -name \*\.pyc -exec rm {} \;
 
 help:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 [![Build Status](https://travis-ci.org/craig5/pybanker.svg?branch=master)](https://travis-ci.org/craig5/pybanker)
 
+## pyBanker
 
-pybanker
-========
+Command line to manage your finances.
 
-Simple command line tool for managing your finances.
+
+### Background
+
+After using several GUI finance managers over the years,
+I got fed up with their inability for any kind of automation.
+Manually adding entries is time consuming.
+The goal of this app is make managing your finances easier
+for those that "live in the terminal".
+

--- a/lib/pybanker/__init__.py
+++ b/lib/pybanker/__init__.py
@@ -28,7 +28,7 @@ class Banker(object):
 
     def _init_logger(self, logger_level=None):
         """Initialize logger. (self.logger)"""
-        logger_name = self.__class__.__name__
+        logger_name = self.global_config.build_logger_name(self)
         self.logger = logging.getLogger(logger_name)
         self.logger.debug('Logger initialized: {0}'.format(logger_name))
 

--- a/lib/pybanker/accounts.py
+++ b/lib/pybanker/accounts.py
@@ -67,7 +67,10 @@ class _SingleAccount(object):
         self.active = data['active']
         self.visible = data['visible']
         self.account_end = data.get('account_end', None)
-        self.short_name = data['short_name']
+        try:
+            self.short_name = data['short_name']
+        except KeyError:
+            self.short_name = self.name
 
     def __str__(self):
         return self.name

--- a/lib/pybanker/shared.py
+++ b/lib/pybanker/shared.py
@@ -29,6 +29,9 @@ class GlobalConfig(object):
     ]
 
     def __init__(self):
+        logger_name = self.build_logger_name(self)
+        self.logger = logging.getLogger(logger_name)
+        self.logger.debug('Config initialized: {}'.format(logger_name))
         self._init_vars()
         # TODO add kwarg for "config_file" to override default
         self.config_file = self.default_config_file
@@ -39,15 +42,17 @@ class GlobalConfig(object):
 
     def _load_config_file(self):
         self.conf = configparser.ConfigParser()
+        self.logger.debug('Reading config file: {}'.format(self.config_file))
         self.conf.read(self.config_file)
 
     @property
     def data_dir(self):
         # TODO add check to make sure 'data_dir' exists in conf
-        raw = self.conf.get('default', 'data_dir')
-        if raw.startswith('/'):
-            return raw
-        return os.path.join(self.home_dir, raw)
+        data_dir = self.conf.get('default', 'data_dir')
+        if not data_dir.startswith('/'):
+            data_dir = os.path.join(self.home_dir, data_dir)
+        self.logger.debug('Data dir: {}'.format(data_dir))
+        return data_dir
 
     @property
     def schedule_file(self):
@@ -56,6 +61,9 @@ class GlobalConfig(object):
     @property
     def accounts_file(self):
         return os.path.join(self.data_dir, 'accounts.yaml')
+
+    def build_logger_name(self, class_object):
+        return '.'.join([self.base_logger_name, class_object.__class__.__name__])
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,20 @@
+[metadata]
+name = pybanker
+version = 0.0.1
+summary = Command line tool to manage personal finances.
+description = Command line and curses tool to manage personal finances.
+author = Craig Sebenik
+#author_email = craig5@users.noreply.github.com
+keywords = finance, checkbook
+url = https://github.com/craig5/pybanker
+
+[options.entry_points]
+console_scripts =
+	pybanker = pybanker.cli:PyBankerCli.main
+
+[options]
+packages = find:
+
 [flake8]
 ignore = E226,E302,E41
 max-line-length = 90

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 Setup script for pybanker (python3).
 """
 # core python packaes
-import os
 import setuptools
 # third party packages
 # custom packages

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Setup script for pybanker (python3)."""
+"""
+Setup script for pybanker (python3).
+"""
 # core python packaes
 import os
 import setuptools
@@ -7,56 +9,15 @@ import setuptools
 # custom packages
 
 
-setup_args = {
-    'name': 'pybanker',
-    'version': '0.0.2',
-    'description': 'Simple command line tool for managing your finances.',
-    'author': 'Craig Sebenik',
-    'author_email': 'craig5@users.noreply.github.com',
-    'url': 'http://www.friedserver.com/',
-    'keywords': ['python', 'python3', 'finance', 'money', 'quicken'],
-}
-#
-_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 _LIB_DIR = 'lib'
-_DATA_DIR = 'data'
-_TESTS_DIR = 'tests'
-_DATA_LIST = ['{0}/*'.format(_DATA_DIR)]
 
 
-setup_args['package_dir'] = {'': _LIB_DIR}
-setup_args['packages'] = setuptools.find_packages(_LIB_DIR)
-setup_args['package_data'] = {'': _DATA_LIST}
-setup_args['include_package_data'] = True
-setup_args['test_suite'] = 'nose2.collector.collector'
+def main():
+    setup_args = dict()
+    setup_args['package_dir'] = {'': _LIB_DIR}
+    setup_args['packages'] = setuptools.find_packages(_LIB_DIR)
+    setuptools.setup(**setup_args)
 
 
-class Info(setuptools.Command):
-    """
-    Show basic info about the package.
-    """
-    description = 'Show package info'
-    user_options = []
-
-    def initialize_options(self):
-        """Init options..."""
-        pass
-
-    def finalize_options(self):
-        """Finalize the things..."""
-        pass
-
-    def run(self):
-        """Really show the info."""
-        print('Package Name: {name}'.format(**setup_args))
-        print('Version: {version}'.format(**setup_args))
-
-
-setup_args['cmdclass'] = {'info': Info}
-setup_args['entry_points'] = {
-    'console_scripts': [
-        'pybanker=pybanker.cli:PyBankerCli.main'
-    ]
-}
-
-setuptools.setup(**setup_args)
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Migrate most metadata out of setup.py into setup.cfg

Minor Makefile updates:
- always upgrade setuptools
- search for python3 in path
- fix find for egg-info dirs (in clean target)

Add some stuff to the readme.

Try to fix the logger... But, it still isn't working.
Some of the "child loggers" don't seem to properly inherit the level
from the main one.
