### PR TITLE
custom exception for missing statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ venv
 
 # tests lib dir
 .lib
+
+# visual studio code
+.vscode/

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
-iPython==8.5.0
+iPython==8.6.0
 ipdb==0.13.9

--- a/lib/pybanker/cli.py
+++ b/lib/pybanker/cli.py
@@ -41,7 +41,7 @@ class PyBankerCli(object):
         self.cli = argparse.ArgumentParser(description=__doc__)
         self.cli.add_argument(
             '--log-level',
-            choices=['debug', 'info', 'warn'],
+            choices=['debug', 'info', 'warn', 'error', 'fatal'],
             help='Change logging level.'
         )
         command_opts = [cur['option'] for cur in self.global_config.commands]
@@ -78,6 +78,9 @@ class PyBankerCli(object):
             bank(self.command)
         except pybanker.shared.ConfigError:
             raise
+        except pybanker.accounts.AccountConfigException as exc:
+            self.logger.fatal(exc)
+            raise SystemExit(11)
 
 
 def main():

--- a/lib/pybanker/frequency_utils.py
+++ b/lib/pybanker/frequency_utils.py
@@ -48,10 +48,16 @@ class FrequencyHelper:
         self.end_dt = end_dt
         if self.end_dt is None:
             self.end_dt = _get_today_dt()
+        self._buffer_days = None
+
+    def _get_default_buffer_days(self):
+        return self.frequency_data['buffer']
 
     @property
     def buffer_days(self):
-        return self.frequency_data['buffer']
+        if self._buffer_days is None:
+            self._buffer_days = self._get_default_buffer_days()
+        return self._buffer_days
 
     @property
     def days_delta(self):
@@ -94,11 +100,11 @@ class FrequencyHelper:
                     latest_doc_dt = self._pop_latest_doc()
                     continue
             else:
-                self.logger.error('No more statments.')
+                self.logger.debug('No more statments.')
             # If "latest_doc_dt" is outside the window, then increment the window first,
             # this should make ""window_start_dt" the DESIRED date, i.e. the "window end".
             window_start_dt = self._increment_frequency(window_start_dt)
-            self.logger.error(f'Missing statement: {window_start_dt}')
+            self.logger.debug(f'Missing statement: {window_start_dt}')
             missing.append(window_start_dt)
         return missing
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 flake8==5.0.4
-pytest-cov==3.0.0
-pytest-mock==3.8.2
-pytest==7.1.3
+pytest-cov==4.0.0
+pytest-mock==3.10.0
+pytest==7.2.0


### PR DESCRIPTION
Create exception specifically for missing statements.
This should allow "real config errors" to be "fatal" and allow
missing statements to just be shown.
(In the future, missing statements may not even create an "error".)

Add error and fatal to log level options.

Add vscode to gitignore.

Update requirements.
