### PR TITLE
refactor statements

### DIFF
--- a/.github/workflows/default-ci.yaml
+++ b/.github/workflows/default-ci.yaml
@@ -7,8 +7,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
-          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/default-ci.yaml
+++ b/.github/workflows/default-ci.yaml
@@ -1,6 +1,8 @@
 name: Default CI (make dev test)
 on:
   - push
+env:
+  DISABLE_VIRTUAL_ENV: true
 jobs:
   build_and_test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# v0.3.0
+
+- Remove python 3.9 and 3.10 support
+  - The older versions were giving errors with `typing`.
+- Major refactor of how statements are managed.
+  - Added `statements.py`.
+  - Added support for multiple statement directories.
+  - Backwards INCOMPATIBLE change: removed default statement directory.
+    - This means every account that relied on that default had to be updated.
+- Start using `dataclasses` more.
+  - Biggest place is reading the various `index.yaml` files.
+- Add `isort`
+- Add `CHANGELOG.md`
+  - Did NOT add changes from older versions.
+- Add minimum coverage number (39%).
+  - This reflects the current number. (Don't want to "fall backwards".)
+
+
+# Older Versions
+
+For older versions, refer to the `tag` annotations.
+
+(I can add those older annotations to this file, if someone asks.)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ PIP_CMD = pip3
 PYTHON_CMD = python3
 PYTEST_CMD = pytest
 FLAKE8_CMD = flake8
+ISORT_CMD = isort
 endif
 
 # To install venv on ubuntu 14.04:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ _dev_reqs:
 _setup_develop:
 	$(PYTHON_CMD) $(SETUP_PY) develop
 
-ci-dev: _local_virtualenv _pip_reqs _setup_develop
+ci-dev: _pip_reqs _setup_develop
 
 dev: ci-dev _dev_reqs
 

--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ To test the GitHub actions config locally, you can run the `act` command.
 It requires `docker` to be running.
 
 (Note: it won't check "everything". But, it is good enough for some validation.)
+
+### Python Versions
+
+I had to remove python 3.9 and 3.10 support due to some differences with
+`typing`.

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,27 @@
 ## Random Todo Items
 
+Infra:
+
+- Convert to pyproject.toml.
+- Add git pre-commit check.
+- Auto publish new versions.
+- Move away from UserDict/OrderedDict/... and use dataclasses.
+- Create test data with new and legacy formats.
+- Move to poetry
+
+
 Data Support:
 
-- add check for up to date "data" dirs
+- Add check for up to date "data" dirs.
+- Verify "shared accounts" actually exist.
+
 
 Tansactions:
 
 - Validate transactions against data.
 - Create summaries of transactions that can compare against data.
+
+
+Tests:
+
+- Get coverage up to 50%

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
-iPython==8.26.0
+iPython==9.4.0
 ipdb==0.13.13

--- a/lib/pybanker/__init__.py
+++ b/lib/pybanker/__init__.py
@@ -1,14 +1,12 @@
 """
 Main class that wraps pybanker functionality
 """
-# core python libraries
 import logging
-# third party libraries
-# custom libraries
-import pybanker.shared
+
 import pybanker.accounts
-import pybanker.schedule
 import pybanker.receipts
+import pybanker.schedule
+import pybanker.shared
 import pybanker.transactions
 
 
@@ -38,14 +36,14 @@ class Banker(object):
         self.logger.debug('Logger initialized: {0}'.format(logger_name))
 
     def load_data(self):
-        self.accounts = pybanker.accounts.Accounts()
+        self.account_manager = pybanker.accounts.AccountManager()
         self.schedule = pybanker.schedule.Schedule()
         self.receipts = pybanker.receipts.Receipts()
         self.transactions = pybanker.transactions.Transactions()
         self.transactions.link_receipts(self.receipts)
 
     def list_accounts(self):
-        self.accounts.show_summary()
+        self.account_manager.show_summary()
 
     def show_schedule(self):
         self.schedule.show_summary()

--- a/lib/pybanker/accounts.py
+++ b/lib/pybanker/accounts.py
@@ -1,69 +1,59 @@
 """
 Classes related to the accounts.
 """
-# core python packages
-import collections
+import dataclasses
 import datetime
-import os
-import re
-# third party packages
+import functools
+import pathlib
+import typing
+
 import yaml
-# custom packages
-import pybanker.shared
+
 import pybanker.frequency_utils
+import pybanker.shared
+import pybanker.statements
 
 
 class AccountConfigException(Exception):
     pass
 
 
-class MissingStatements(Exception):
+@dataclasses.dataclass
+class AccountManager:
 
-    def __init__(self, message, account_name, missing):
-        super().__init__(message)
-        self.account_name = account_name
-        self.missing = missing
-
-
-class Accounts(collections.OrderedDict):
-
-    def __init__(self):
-        super().__init__()
-        self.config = pybanker.shared.GlobalConfig()
-        self.logger = self.config.build_logger(self)
-        self._accounts = None
+    def __post_init__(self):
+        self.global_config = pybanker.shared.GlobalConfig()
+        self.logger = self.global_config.build_logger(self)
 
     @property
     def data_directory(self):
-        return self.config.accounts_directory
+        return pathlib.Path(self.global_config.accounts_directory)
 
-    def _get_accounts(self):
+    @functools.cached_property
+    def accounts(self):
         self.logger.debug(f'Loading accounts: {self.data_directory}')
-        try:
-            contents = os.listdir(self.data_directory)
-        except FileNotFoundError:
+        if not self.data_directory.exists():
             msg = f'Account directory not found: {self.data_directory}'
             raise AccountConfigException(msg)
-        self.logger.debug(f'Elements in accounts dir: {len(contents)}')
         accounts = dict()
-        for cur in sorted(contents):
-            full = os.path.join(self.data_directory, cur)
-            if cur.startswith('.'):
-                self.logger.debug(f'Skipping dotfile: {cur}')
+        for cur in sorted(self.data_directory.iterdir()):
+            if not cur.is_dir():
+                self.logger.debug('Skipping non-dir: %s', cur)
                 continue
-            if not os.path.isdir(full):
-                self.logger.debug(f'Skipping (not a dir): {full}')
+            if cur.stem.startswith('.'):
+                self.logger.debug('Skipping dotdir: %s', cur)
                 continue
-            new_account = _AccountItem(full)
-            accounts[new_account.short_name] = new_account
-            self.logger.debug('Added account: {}'.format(new_account.name))
+            try:
+                new_account = _SingleAccount(cur)
+            except Exception as exc:
+                self.logger.exception(exc)
+                self.logger.error('Could not create account: %s', cur)
+                breakpoint()
+                raise
+            accounts[new_account.slug] = new_account
+            self.logger.debug('Added account: {}'.format(new_account.slug))
+        self.logger.debug('Number accounts found: %d', len(accounts))
         return accounts
-
-    @property
-    def accounts(self):
-        if self._accounts is None:
-            self._accounts = self._get_accounts()
-        return self._accounts
 
     def verify_data(self):
         self.logger.debug('Verifying account data.')
@@ -77,151 +67,151 @@ class Accounts(collections.OrderedDict):
             print(cur_obj.get_summary_output())
 
 
-class _AccountItem(collections.UserDict):
+@dataclasses.dataclass
+class _AccountIndexData:
+    index_path: pathlib.Path
+    slug: str
+    name: str
+    active: bool
+    visible: bool
+    account_type: str  # Maybe make this an enum?
+    start_date: datetime.date
+    statement_period: str  # TODO make this an enum
+    # optional
+    short_name: typing.Optional[str] = None
+    no_statements: typing.Optional[bool] = False
+    url: typing.Optional[str] = None
+    bills_url: typing.Optional[str] = None
+    statement_url: typing.Optional[str] = None
+    shared_statement_account: typing.Optional[str] = None
+    account_endings: typing.Optional[list[str]] = None
+    # TODO need to remove the legacy "singular"
+    statements_directory: typing.Optional[str] = None
+    statements_directories: typing.Optional[list[str]] = None
+    # legacy/unused???
+    statement_date: typing.Optional[str] = None
 
-    def __init__(self, data_directory):
-        """
-        :param data: Dictionary containing the basic account data.
-        """
-        self.config = pybanker.shared.GlobalConfig()
-        self.logger = self.config.build_logger(self)
-        self.data_directory = data_directory
-        index_data = self._read_index_file()
-        super().__init__(**index_data)
-        self._statements_directory = None
-        self._statements_index = None
-        self._verify_core_data()
-        if self.is_cash():
-            self.logger.debug('Cash account: not loading/verifying statments.')
-        elif self.has_shared_statements():
-            self.logger.debug(f'Shared statements for: {self.name}')
-        else:
-            self._load_statements()
-            try:
-                self._verify_statements()
-            except MissingStatements as exc:
-                count = len(exc.missing)
-                self.logger.error(f'Missing statements: {self} ({count})')
+    def __post_init__(self):
+        self.global_config = pybanker.shared.GlobalConfig()
+        self.logger = self.global_config.build_logger(self)
 
-    def __str__(self):
-        return self['name']
-
-    @property
-    def home_dir(self):
-        return self.config.home_dir
-
-    @property
-    def short_name(self):
-        return os.path.basename(self.data_directory)
-
-    @property
-    def index_file(self):
-        return os.path.join(self.data_directory, 'index.yaml')
-
-    def _read_index_file(self):
-        self.logger.debug(f'Reading index file ({self.short_name}): {self.index_file}')
+    @classmethod
+    def from_file(cls, slug: str, index_path: pathlib.Path):
+        global_config = pybanker.shared.GlobalConfig()
+        logger = global_config.build_logger(cls)
+        logger.debug('Reading index file: %s', index_path)
         try:
-            with open(self.index_file, 'r') as fp:
+            with open(index_path, 'r') as fp:
                 data = yaml.safe_load(fp)
         except FileNotFoundError:
-            msg = f'Account missing index file: {self.data_directory}'
+            msg = f'Account missing index file: {index_path}'
             raise AccountConfigException(msg)
         except yaml.scanner.ScannerError as e:
-            self.logger.exception(e)
-            msg = f'Canot parse YAML file: {self.index_file}'
+            logger.exception(e)
+            msg = f'Canot parse YAML file: {index_path}'
             raise AccountConfigException(msg)
-        return data
+        if 'type' in data:
+            logger.warning('Legacy index element: type')
+            data['account_type'] = data['type']
+            del data['type']
+        if data.get('shared_statement_account', None) is not None:
+            data['statement_period'] = None
+            data['statements_directories'] = []
+            data['start_date'] = None
+        try:
+            this = cls(slug=slug, index_path=index_path, **data)
+        except Exception as exc:
+            logger.exception(exc)
+            breakpoint()
+        return this
 
-    def _default_statements_directory_basename(self):
-        return 'statements'
 
-    @property
-    def statements_directory_basename(self):
-        key = 'statements_directory'
-        state_dir = self.get(key, None)
-        if state_dir is not None:
-            self.logger.debug(f'Found key "{key}": {state_dir}')
-            return state_dir
-        self.logger.debug("Using default statements directory.")
-        return self._default_statements_directory_basename()
+@dataclasses.dataclass
+class _SingleAccount:
+    data_directory: pathlib.Path
+    slug: str = dataclasses.field(init=False)
 
-    def _calc_statements_directory(self):
-        subdir = os.path.join(self.data_directory, self.statements_directory_basename)
-        if os.path.exists(subdir):
-            self.logger.debug(f'Using subdir for statements: {subdir}')
-            return subdir
-        raise AccountConfigException(f'No statements directory: {self.name}:{subdir}')
-
-    @property
-    def statements_directory(self):
-        if self._statements_directory is None:
-            self._statements_directory = self._calc_statements_directory()
-        return self._statements_directory
-
-    def _load_statements_index_file(self):
-        index_file = os.path.join(self.statements_directory, 'index.yaml')
-        if os.path.exists(index_file):
-            with open(index_file, 'r') as fp:
-                data = yaml.safe_load(fp)
-                return data
-        return dict()
-
-    @property
-    def statements_index(self):
-        if self._statements_index is None:
-            self._statements_index = self._load_statements_index_file()
-        return self._statements_index
-
-    @property
-    def name_formats(self):
-        return self.statements_index.get('name_formats', list())
-
-    @property
-    def account_id(self):
-        """
-        The 'short name' for this account.
-        """
-        return self['short_name']
-
-    @property
-    def type(self):
-        return self['type']
-
-    @property
-    def name(self):
-        return self['name']
-
-    def is_cash(self):
-        if self.type == 'cash':
-            return True
-        return False
+    def __post_init__(self):
+        """Initialize the computed values."""
+        self.global_config = pybanker.shared.GlobalConfig()
+        self.logger = self.global_config.build_logger(self)
+        self.logger.debug('Loadding account from dir: %s', self.data_directory)
+        self.path = pathlib.Path(self.data_directory)
+        self.slug = self.path.stem
+        self.index_file = self.data_directory / 'index.yaml'
+        self.index_data = _AccountIndexData.from_file(slug=self.slug, index_path=self.index_file)
+        self.statements_manager = pybanker.statements.StatementsManager(
+            account_key=self.slug,
+            base_path=self.path,
+            paths=self.statements_paths,
+            account_index_data=self.index_data,
+        )
+        self._verify_core_data()
+        self.statements_manager.verify()
 
     def has_shared_statements(self):
-        if 'shared_statement_account' in self:
+        # TODO verify that the shared account actually exists.
+        if self.index_data.shared_statement_account is not None:
             return True
         return False
 
-    def build_summary_data(self):
-        """
-        Build a dictionary with the "summary data" for this account.
-        """
-        data = {
-            'Name': self['name'],
-            'Type': self['type']
-        }
-        return {self.short_name: data}
+    def has_statements(self):
+        if self.has_shared_statements() is True:
+            return False
+        return not self.index_data.no_statements
 
-    def get_required_fields(self):
+    @functools.cached_property
+    def statements_paths(self):
+        paths = None
+        if not self.has_statements():
+            self.logger.info('No statements by config: %s', self.slug)
+            return []
+        # First, look for the legacy "single" entry.
+        single_key = 'statements_directory'
+        single = getattr(self.index_data, single_key, None)
+        # Then, then new list/array format.
+        multi_key = 'statements_directories'
+        multi = getattr(self.index_data, multi_key, None)
+        if single is None and multi is not None:
+            dirs = multi
+        elif single is not None and multi is None:
+            dirs = [single]
+        elif single is None and multi is None:
+            raise AccountConfigException(f'No statement dirs defined: {self.slug}')
+        else:
+            # One cannot define BOTH.
+            raise AccountConfigException(
+                f'Both {single_key} and {multi_key} are defined for {self.slug}.')
+        self.logger.debug('Statement dir: %s', dirs)
+        paths = [self.path / cur for cur in dirs]
+        self.logger.debug('Statement paths: %s', paths)
+        return paths
+
+    @functools.cached_property
+    def required_fields(self):
         reqs = list()
-        if not self.is_cash() and not self.has_shared_statements():
+        if self.has_statements():
             reqs.append('start_date')
-            reqs.append('statement_period')
         return reqs
 
-    def get_summary_output(self):
+    def _verify_core_data(self):
+        """Run any account verifcation steps needed.
+
+        Note: this used to be more important before using "dataclasses".
+            Now, the `dataclass` structure enforces any required fields.
         """
-        Return a string that can be printed that shows this account's summary data.
-        """
+        return
+
+    def build_summary_data(self):
+        """Build a dictionary with the "summary data" for this account."""
+        data = {
+            'Name': self.index_data.name,
+            'Type': self.index_data.account_type,
+        }
+        return {self.slug: data}
+
+    def get_verbose_output(self):
+        """Return a string that can be printed that shows this account's data."""
         output = yaml.dump(
             self.build_summary_data(),
             indent=2,
@@ -230,124 +220,16 @@ class _AccountItem(collections.UserDict):
         output = output.rstrip('\n')
         return output
 
-    def _verify_core_data(self):
-        fails = list()
-        for req in self.get_required_fields():
-            if req not in self:
-                fails.append(f'Missing required key ({self.name}): {req}')
-        if 'statement_period' in self.get_required_fields():
-            period = self.get('statement_period', None)
-            if not pybanker.frequency_utils.is_supported_type(period):
-                fails.append(f'Unsupported statement period: {period}')
-        if len(fails) > 0:
-            raise AccountConfigException(fails)
-
-    def _parse_date_file_name(self, name):
-        try:
-            return self._parse_date_string(name.rstrip('.pdf'))
-        except Exception:
-            raise
-
-    def _parse_date_string(self, date_string):
-        for name_format in self.name_formats:
-            filename_matcher = re.compile(name_format)
-            date_matches = filename_matcher.match(date_string)
-            if date_matches is None:
-                continue
-            dt_date = datetime.date(
-                int(date_matches.group(1)),
-                int(date_matches.group(2)),
-                int(date_matches.group(3))
-            )
-            return dt_date
-        raise AccountConfigException(f'Cannot parse date string: {self.name} -> {date_string}')
-
-    def _is_skipable_statements_file(self, filename):
-        if filename.startswith('.'):
-            return True
-        if filename == 'index.yaml':
-            return True
-        return False
-
-    def _load_statements(self):
-        self.statements = dict()
-        self.statements.update(self._get_null_statements())
-        self.statements.update(self._get_known_missing_statements())
-        filename_date_map = self._get_filename_date_map_entries()
-        for cur in os.listdir(self.statements_directory):
-            if self._is_skipable_statements_file(cur):
-                continue
-            item = {'full_path': os.path.join(self.statements_directory, cur)}
-            cur_dt_obj = filename_date_map.get(cur, None)
-            # If the current file is in the "date map",
-            # then use the value of the map's key as the "date string".
-            if cur_dt_obj is not None:
-                self.logger.debug(f"Found in filename_date_map: {cur_dt_obj}")
-                cur_key = cur_dt_obj.isoformat()
-            else:
-                item['date'] = self._parse_date_file_name(cur)
-                cur_key = item['date'].isoformat()
-            if cur_key in self.statements:
-                raise Exception(f'Duplicate statements: {self.name}:{cur_key}')
-            self.statements[cur_key] = item
-
-    def _convert_raw_to_datetimes(self, key_name):
-        raw_list = self.statements_index.get(key_name, list())
-        converted_list = list()
-        self.logger.debug(f'Found {key_name} statements: {self.name}:{len(raw_list)}')
-        for cur in raw_list:
-            self.logger.debug(f'Adding {key_name}: {self.name}:{cur}')
-            # Data cleanup, first...
-            if isinstance(cur, int):
-                cur = str(cur)
-            # Convert to datetime, if needed.
-            if isinstance(cur, str):
-                dt_date = self._parse_date_file_name(cur)
-            elif isinstance(cur, datetime.date):
-                dt_date = cur
-            else:
-                # TODO better exception
-                raise Exception(f'Could not convert to dt: {cur}')
-            cur_key = dt_date.isoformat()
-            converted_list.append(cur_key)
-        return converted_list
-
-    def _get_filename_date_map_entries(self):
-        key = 'filename_date_map'
-        return self.statements_index.get(key, dict())
-
-    def _get_null_statements(self):
-        nulls = dict()
-        for cur in self._convert_raw_to_datetimes('null_statements'):
-            nulls[cur] = None
-        return nulls
-
-    def _get_known_missing_statements(self):
-        missing = dict()
-        for cur in self._convert_raw_to_datetimes('known_missing_statements'):
-            missing[cur] = None
-        return missing
-
-    def _verify_statements(self):
-        if self.is_cash():
-            return
-        if self.has_shared_statements():
-            return
-        statement_dates = list()
-        for cur in sorted(self.statements.keys()):
-            statement_dates.append(datetime.date.fromisoformat(cur))
-        freq_helper = pybanker.frequency_utils.FrequencyHelper(
-            self['statement_period'], statement_dates, self['start_date'])
-        self.missing_statement_dates = freq_helper.find_missing_statement_dates()
-        if len(self.missing_statement_dates) > 0:
-            for cur in self.missing_statement_dates:
-                self.logger.error(f'Missing statement: {self.name}: {cur}')
-            msg = 'Missing statements: {0}: {1}'.format(
-                self.name, self.missing_statement_dates)
-            raise MissingStatements(msg, self.name, self.missing_statement_dates)
-
-    def verify_data(self):
-        raise NotImplementedError('Verify data is not done in accounts item.')
+    def get_summary_output(self):
+        """Return a string that can be printed that shows this account's summary data."""
+        # TODO use prettytable
+        format_string = '{name:50s} [{slug:22s}]: {account_type}'
+        output = format_string.format(
+            name=self.index_data.name,
+            slug=self.slug,
+            account_type=self.index_data.account_type
+        )
+        return output
 
 
 if __name__ == '__main__':

--- a/lib/pybanker/cli.py
+++ b/lib/pybanker/cli.py
@@ -1,11 +1,9 @@
 """
 Command line tool to mange your finances.
 """
-# core python packages
 import argparse
 import logging
-# third party packages
-# custom packages
+
 import pybanker.shared
 
 

--- a/lib/pybanker/frequency_utils.py
+++ b/lib/pybanker/frequency_utils.py
@@ -1,13 +1,11 @@
 """
 Classes related to the accounts.
 """
-# core python packages
 import datetime
-# third party packages
-# custom packages
+
 import pybanker.shared
 
-
+# TODO Merge with statements._StatementPeriod
 _FREQUENCY_DATA = {
     'bi-weekly': {'days': 14, 'buffer': 2},
     'monthly': {'days': 30, 'buffer': 5},
@@ -44,6 +42,13 @@ class FrequencyHelper:
         except KeyError:
             raise UnknownFrequency(f'Unknown frequency: {self.frequency}')
         self.statement_dates = statement_dates
+        # Incoming dates SHOULD be sorted.
+        # If not, sorted, sort them and report a warning.
+        sorted_statements = sorted(self.statement_dates)
+        if sorted_statements != self.statement_dates:
+            self.logger.warning('Statements are not sorted.')
+            self.statement_dates = sorted_statements
+            breakpoint()
         self.start_dt = start_dt
         self.end_dt = end_dt
         if self.end_dt is None:

--- a/lib/pybanker/receipts.py
+++ b/lib/pybanker/receipts.py
@@ -1,11 +1,9 @@
 """
 """
-# core python packages
 import collections
 import logging
 import os
-# third party packages
-# custom packages
+
 import pybanker.shared
 
 

--- a/lib/pybanker/schedule.py
+++ b/lib/pybanker/schedule.py
@@ -1,11 +1,10 @@
 """
 Classes to handle the scheduled items.
 """
-# core python libraries
 import logging
-# third party libraries
+
 import yaml
-# custom libraries
+
 import pybanker.shared
 
 

--- a/lib/pybanker/shared.py
+++ b/lib/pybanker/shared.py
@@ -1,14 +1,10 @@
 """
 Global config for pybanker.
 """
-# core python libraries
 import configparser
+import importlib.metadata
 import logging
 import os
-import pkg_resources
-# third party libraries
-# custom libraries
-
 
 _PACKAGE_NAME = 'pybanker'
 
@@ -24,8 +20,6 @@ def home_dir():
 class GlobalConfig(object):
     base_logger_name = _PACKAGE_NAME
     default_logger_level = logging.WARN
-    version = pkg_resources.get_distribution(_PACKAGE_NAME).version
-    #
     package_name = _PACKAGE_NAME
     logger_level = logging.INFO
     # The first one ([0]) is the default.
@@ -37,6 +31,7 @@ class GlobalConfig(object):
 
     def __init__(self):
         self.logger = self.build_logger(self)
+        self.version = importlib.metadata.version(self.package_name)
         self._init_vars()
         # TODO add kwarg for "config_file" to override default
         self._config_file = None
@@ -92,7 +87,12 @@ class GlobalConfig(object):
         return logger
 
     def build_logger_name(self, class_object):
-        return '.'.join([self.base_logger_name, class_object.__class__.__name__])
+        this_name = class_object.__class__.__name__
+        # Handles the case when it is called from a classmethod. Eg ...build_logger(cls)
+        if this_name == 'type':
+            this_name = class_object.__name__
+        name = '.'.join([self.base_logger_name, this_name])
+        return name
 
 
 if __name__ == '__main__':

--- a/lib/pybanker/statements.py
+++ b/lib/pybanker/statements.py
@@ -1,0 +1,284 @@
+"""Helpers to manage statements."""
+import dataclasses
+import datetime
+import enum
+import functools
+import pathlib
+import re
+import typing
+
+import yaml
+
+import pybanker.frequency_utils
+import pybanker.shared
+
+
+class ConfigError(Exception):
+    pass
+
+
+class MissingStatements(Exception):
+
+    def __init__(self, message, account_name, missing):
+        super().__init__(message)
+        self.account_name = account_name
+        self.missing = missing
+
+
+def _parse_date_string(date_string, name_formats):
+    for cur_format in name_formats:
+        filename_matcher = re.compile(cur_format)
+        date_matches = filename_matcher.match(date_string)
+        if date_matches is None:
+            continue
+        try:
+            dt_date = datetime.date(
+                int(date_matches.group(1)),
+                int(date_matches.group(2)),
+                int(date_matches.group(3))
+            )
+        except Exception:
+            raise
+        return dt_date
+    raise ConfigError(f'Cannot parse date string: {date_string}')
+
+
+@dataclasses.dataclass
+class _StatementItem:
+    date_dt: datetime.date
+    path: typing.Optional[pathlib.Path] = None
+
+    def __post_init__(self):
+        self.global_config = pybanker.shared.GlobalConfig()
+        self.logger = self.global_config.build_logger(self)
+
+    @classmethod
+    def from_file(cls, path, name_formats):
+        stem = path.stem
+        date_dt = _parse_date_string(stem, name_formats)
+        return cls(date_dt=date_dt, path=path)
+
+    @classmethod
+    def from_config(cls, date):
+        if isinstance(date, datetime.date):
+            return cls(date_dt=date)
+        try:
+            dt = datetime.datetime.strptime(str(date), '%Y%m%d')
+            return cls(date_dt=dt.date())
+        except Exception:
+            pass
+        # TODO unit test to verify this behavior
+        breakpoint()
+
+
+class _StatementPeriod(enum.Enum):
+    bi_weekly = 'bi-weekly'
+    monthly = 'monthly'
+    quarterly = 'quarterly'
+
+
+@dataclasses.dataclass
+class _IndexData:
+    index_path: pathlib.Path
+    name_formats: list[str]
+    start_date: datetime.date
+    period: str
+    period_ref: _StatementPeriod = dataclasses.field(init=False)
+    # optional
+    end_date: typing.Optional[datetime.date] = None
+    null_statements: typing.Optional[list[datetime.date]] = None
+    known_missing_statements: typing.Optional[list[datetime.date]] = None
+    filename_date_map: typing.Optional[dict[str: datetime.date]] = None
+
+    def __post_init__(self) -> None:
+        self.config = pybanker.shared.GlobalConfig()
+        self.logger = self.config.build_logger(self)
+        self.period_ref = _StatementPeriod(self.period)
+        self.null_statements = self._transform_statements_list('null_statements')
+        self.known_missing_statements = self._transform_statements_list('known_missing_statements')
+        if self.filename_date_map is None:
+            self.filename_date_map = {}
+
+    def _transform_statements_list(self, cur_key) -> list:
+        """Transform a list of dates in statement items."""
+        raw_list = getattr(self, cur_key, [])
+        items = []
+        if raw_list is not None:
+            for cur in raw_list:
+                new_item = _StatementItem.from_config(cur)
+                items.append(new_item)
+        return items
+
+    @staticmethod
+    def read_index_file(index_path: pathlib.Path) -> dict:
+        with index_path.open() as fp:
+            data = yaml.safe_load(fp)
+        return data
+
+    @classmethod
+    def from_file(cls, index_path: pathlib.Path):
+        if not index_path.exists():
+            raise ConfigError(f'Index file does not exist: {index_path}')
+        # This is overkill... :(
+        config = pybanker.shared.GlobalConfig()
+        logger = config.build_logger(cls)
+        logger.debug('Reading statements index: %s', index_path)
+        data = cls.read_index_file(index_path)
+        try:
+            this = cls(index_path=index_path, **data)
+        except Exception as exc:
+            # TODO make this a real exception once the "legacy support" is removed.
+            # logger.exception(exc)
+            logger.debug('Could not create from file: %s', exc)
+            this = None
+        return this
+
+
+@dataclasses.dataclass
+class _StatementsDirectory:
+    path: pathlib.Path
+    account_index_data: object
+
+    def __post_init__(self):
+        self.config = pybanker.shared.GlobalConfig()
+        self.logger = self.config.build_logger(self)
+        self.index_path = self.path / 'index.yaml'
+        try:
+            self.index_data = _IndexData.from_file(self.index_path)
+        except ConfigError:
+            # TODO temporary... until all index files are created, use the legacy method
+            self.logger.error('Ignoring missing index file for now: %s', self.index_path)
+            self.index_data = None
+        if self.index_data is None:
+            self.index_data = self._legacy_index_data()
+        self.freq_helper = pybanker.frequency_utils.FrequencyHelper(
+            self.index_data.period,
+            [cur.date_dt for cur in self.statements],
+            self.index_data.start_date,
+            self.index_data.end_date,
+        )
+        self.missing_statement_dates = self.freq_helper.find_missing_statement_dates()
+
+    def _legacy_index_data(self):
+        self.logger.warning('Using LEGACY index data: %s', self)
+        try:
+            index_data = _IndexData.read_index_file(self.index_path)
+        except FileNotFoundError:
+            self.logger.error('Ignoring missing index file for now: %s', self.index_path)
+            index_data = {
+                'name_formats': [r'^(\d{4})-(\d{2})-(\d{2})'],
+            }
+        defaults = {
+            'name_formats': [r'^(\d{4})-(\d{2})-(\d{2})'],
+            'start_date': self.account_index_data.start_date,
+            'period': self.account_index_data.statement_period,
+        }
+        for cur_key, cur_default in defaults.items():
+            if cur_key not in index_data:
+                self.logger.debug('Adding default (%s): %s', self.path, cur_key)
+                index_data[cur_key] = cur_default
+        try:
+            this = _IndexData(index_path=self.index_path, **index_data)
+        except Exception as exc:
+            self.logger.exception(exc)
+            breakpoint()
+        return this
+
+    @functools.cached_property
+    def actual_file_paths(self):
+        actual = []
+        skip_list = ['index']
+        for cur in sorted(self.path.iterdir()):
+            cur_stem = cur.stem
+            if cur_stem in skip_list:
+                self.logger.debug('Skipping from skip_list: %s', cur)
+                continue
+            if cur_stem.startswith('.'):
+                self.logger.debug('Skipping dot file: %s', cur)
+                continue
+            actual.append(cur)
+        return actual
+
+    @functools.cached_property
+    def statements(self):
+        self.logger.debug('Loading statements: %s', self)
+        statements = []
+        found_dts = []
+        actual_file_paths = self.actual_file_paths
+        for cur_file, cur_dt in self.index_data.filename_date_map.items():
+            cur_path = self.path / cur_file
+            new_item = _StatementItem(
+                path=cur_path,
+                date_dt=cur_dt,
+            )
+            # Remove the current file from the "actual" list.
+            try:
+                actual_file_paths.remove(cur_path)
+            except ValueError:
+                self.logger.error(f'File in filename_date_map does not exist: {cur_path}')
+                breakpoint()
+            found_dts.append(new_item.date_dt)
+            statements.append(new_item)
+        for cur in self.index_data.null_statements:
+            if cur.date_dt in found_dts:
+                raise ConfigError(f'Duplicate dates: {cur.date_dt}')
+            found_dts.append(cur.date_dt)
+            statements.append(cur)
+        for cur in self.index_data.known_missing_statements:
+            if cur.date_dt in found_dts:
+                breakpoint()
+                raise ConfigError(f'Duplicate dates: {cur.date_dt}')
+            found_dts.append(cur.date_dt)
+            statements.append(cur)
+        for cur in actual_file_paths:
+            new_item = _StatementItem.from_file(cur, self.index_data.name_formats)
+            if new_item.date_dt in found_dts:
+                raise ConfigError(f'Duplicate dates: {new_item.date_dt}')
+            found_dts.append(new_item.date_dt)
+            statements.append(new_item)
+        # Sort the statements by date.
+        sorted_statements = sorted(statements, key=lambda cur: cur.date_dt)
+        return sorted_statements
+
+    def verify(self):
+        self.logger.debug('Verify statements dir: %s', self)
+        if len(self.missing_statement_dates) > 0:
+            cur_dir = self.path.stem
+            slug = self.account_index_data.slug
+            for cur in self.missing_statement_dates:
+                self.logger.error('Missing statement: %s/%s - %s', slug, cur_dir, cur)
+
+
+@dataclasses.dataclass
+class StatementsManager:
+    account_key: str
+    base_path: pathlib.Path
+    paths: list[pathlib.Path]
+    account_index_data: object
+
+    def __post_init__(self):
+        self.config = pybanker.shared.GlobalConfig()
+        self.logger = self.config.build_logger(self)
+        #
+        self._init_dirs()
+
+    def _init_dirs(self):
+        self.logger.debug('Init dirs: %s', self)
+        self.statements_directories = list()
+        for cur in self.paths:
+            full_path = self.base_path / cur
+            new_st_dir = _StatementsDirectory(
+                path=full_path,
+                account_index_data=self.account_index_data
+            )
+            self.statements_directories.append(new_st_dir)
+        self.logger.debug('Statements dirs: %s', self.statements_directories)
+
+    @functools.cached_property
+    def statements(self):
+        breakpoint()
+
+    def verify(self):
+        self.logger.debug('Verifying statements: %s', self.account_key)
+        for cur in self.statements_directories:
+            cur.verify()

--- a/lib/pybanker/transactions.py
+++ b/lib/pybanker/transactions.py
@@ -1,13 +1,12 @@
 """
 """
-# core python packages
 import collections
 import hashlib
 import os
 import re
-# third party packages
+
 import yaml
-# custom packages
+
 import pybanker.shared
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,5 @@ addopts = -ra --cov=lib
 	--cov-report term
 	--cov-report term-missing
 	--cov-report xml
+	--cov-fail-under=39
 #	--cov-report annotate

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description = Command line and curses tool to manage personal finances.
 author = Craig Sebenik
 author_email = craig5@users.noreply.github.com
 url = https://github.com/craig5/pybanker
-long_description = file: README.rst, CHANGELOG.rst, LICENSE.rst
+long_description = file: README.md, CHANGELOG.md, LICENSE
 keywords = python, python3, finance, money, quicken, finance, checkbook
 license = GNU GPLv3
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python3
-"""
-Setup script for pybanker (python3).
-"""
-# core python packaes
+"""Setup script for pybanker (python3)."""
 import setuptools
-# third party packages
-# custom packages
-import git_tools
 
+import git_tools
 
 _LIB_DIR = 'lib'
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
-flake8==7.1.1
-pytest-cov==5.0.0
-pytest-mock==3.14.0
-pytest==8.3.2
+flake8==7.3.0
+isort==6.0.1
+pytest-cov==6.2.1
+pytest-mock==3.14.1
+pytest==8.4.1

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3 -B
 """
 """
-# python core packages
-# third party packages
-# custom packages
 import utils_for_tests
 
 

--- a/tests/test_frequency_utils.py
+++ b/tests/test_frequency_utils.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3 -B
 """Test for pybanker.frequency_utils class and routines."""
-# python core packages
 import configparser
 import datetime
-# third party packages
+
 import pytest
-# custom packages
+
 import pybanker.frequency_utils
 
 

--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3 -B
-"""
-Test the basic formatting of the python code.
-"""
-# python core packages
-# third party packages
-# custom packages
+"""Test the basic formatting of the python code."""
 import utils_for_tests
 
 

--- a/tests/utils_for_tests.py
+++ b/tests/utils_for_tests.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python -B
 """
 Some generic utilities for the tests.
+
+
+The name of this package is a little odd...
+The test collector (nose) will grab anything that starts with "test_".
+So, I avoided that prefix and this was the best I could come up with...
+
+TODO: verify this filename since moving away from nose.
+Eg I think pytest uses a standard name for shared routines.
 """
-# The name of this package is a little odd...
-# The test collector (nose) will grab anything that starts with "test_".
-# So, I avoided that prefix and this was the best I could come up with...
-# python core libraries
 import logging
 import os
-# third party libraries
-import flake8.api.legacy
 import unittest
+
+import flake8.api.legacy
 
 
 class BaseTestCase(unittest.TestCase):


### PR DESCRIPTION
- Remove python 3.9 and 3.10 support
  - The older versions were giving errors with `typing`.
- Major refactor of how statements are managed.
  - Added `statements.py`.
  - Added support for multiple statement directories.
  - Backwards INCOMPATIBLE change: removed default statement directory.
    - This means every account that relied on that default had to be updated.
- Start using `dataclasses` more.
  - Biggest place is reading the various `index.yaml` files.
- Add `isort`
- Add `CHANGELOG.md`
  - Did NOT add changes from older versions.
- Add minimum coverage number (39%).
  - This reflects the current number. (Don't want to "fall backwards".)
